### PR TITLE
Upgrading amalgalite to v. 1.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.2.6'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
-gem 'amalgalite'
+gem 'amalgalite', '1.1.2' #, git: "git://github.com/copiousfreetime/amalgalite.git"
 gem 'postgres-pr'
 gem 'ruby-mysql', '~> 2.9.10'
 gem 'mongo', '1.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  amalgalite
+  amalgalite (= 1.1.2)
   bson
   bson_ext
   coffee-rails (~> 3.2.1)


### PR DESCRIPTION
Bumped version of amalgalite to version 1.1.2. This resolves issues 5: "can't make amalgalite gem".

ERROR:  Error installing amalgalite:
ERROR: Failed to build gem native extension.

I originally solved the issue by pointing to github.
gem 'amalgalite', '1.3.0', git: "git://github.com/copiousfreetime/amalgalite.git"

But I prefer using 1.1.2 so that Labrador isn't dependent on the current state of master.
