### PR TITLE
Labrador::App.initialize: Default @path to @name

### DIFF
--- a/lib/labrador/app.rb
+++ b/lib/labrador/app.rb
@@ -71,7 +71,7 @@ module Labrador
     #
     def initialize(attributes = {})
       @name     = attributes[:name] || (raise ArgumentError.new('Missing attribute :name'))
-      @path     = attributes[:path]
+      @path     = attributes[:path] || @name
       @session  = attributes[:session]
       @virtual  = attributes[:virtual]
       @adapter_errors = []


### PR DESCRIPTION
Without this change I get null `path`s all over the place on the backend and frontend. It appears that `path` is simply [never supplied](https://github.com/jdanbrown/labrador/blob/ebf5996c7d5c48f0c6cda7ac6561bf32442aab14/lib/labrador/app.rb#L39).

Am I missing something?
